### PR TITLE
Allow changing unnamed buffer titles

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -165,7 +165,8 @@ The available configuration are:
             sort_by = 'insert_after_current' |'insert_at_end' | 'id' | 'extension' | 'relative_directory' | 'directory' | 'tabs' | function(buffer_a, buffer_b)
                 -- add custom logic
                 return buffer_a.modified > buffer_b.modified
-            end
+            end,
+            unnamed_title = "[No Name]"
         }
     }
 <

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -659,6 +659,7 @@ local function get_defaults()
     groups = { items = {}, options = { toggle_hidden_on_enter = true } },
     hover = { enabled = false, reveal = {}, delay = 200 },
     debug = { logging = false },
+    unnamed_title = "[No Name]",
   }
   return { options = opts, highlights = derive_colors(opts.style_preset) }
 end

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -2,6 +2,7 @@ local lazy = require("bufferline.lazy")
 local utils = lazy.require("bufferline.utils") ---@module "bufferline.utils"
 local log = lazy.require("bufferline.utils.log") ---@module "bufferline.utils.log"
 local constants = lazy.require("bufferline.constants") ---@module "bufferline.constants"
+local config = lazy.require("bufferline.config") ---@module "bufferline.config"
 
 local M = {}
 
@@ -172,7 +173,8 @@ function Buffer:new(buf)
     extension = buf.extension,
     type = buf.buftype,
   })
-  local name = "[No Name]"
+  local name = config.options.unnamed_title
+
   if buf.path and #buf.path > 0 then
     name = fn.fnamemodify(buf.path, ":t")
     name = is_directory and name .. "/" or name

--- a/lua/bufferline/types.lua
+++ b/lua/bufferline/types.lua
@@ -64,6 +64,7 @@
 ---@field public groups bufferline.GroupOpts
 ---@field public themable boolean
 ---@field public hover bufferline.HoverOptions
+---@field public unnamed_title string
 
 ---@class bufferline.HLGroup
 ---@field fg string


### PR DESCRIPTION
This adds a new config option `unnamed_title` to support changing the name of unnamed buffers from `[No Name]` to anything the user wants (e.g. `Untitled`).